### PR TITLE
Project scaffolding: Go module, CLI entry point, and build setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # If you prefer the allow list template instead of the deny list, see community template:
 # https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
 #
+# Build output
+bin/
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+BINARY  := blackwood
+OUTDIR  := bin
+GOFLAGS ?=
+
+.PHONY: build clean test install
+
+build:
+	go build $(GOFLAGS) -o $(OUTDIR)/$(BINARY) ./cmd/blackwood
+
+clean:
+	rm -rf $(OUTDIR)
+
+test:
+	go test ./...
+
+install:
+	go install ./cmd/blackwood

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
-# blackwood
-Synchronizes viwoods notes into Obsidian
+# Blackwood
+
+A daemon that watches a directory for new [viwoods](https://viwoods.com) notes files and runs configurable hooks on them. Intended to run under systemd.
+
+## Build
+
+```sh
+make build      # produces bin/blackwood
+make test
+make install    # go install
+```
+
+## Usage
+
+```sh
+blackwood --config path/to/config.yaml --watch-dir /path/to/notes
+```
+
+| Flag | Description |
+|------|-------------|
+| `--config` | Path to the configuration file |
+| `--watch-dir` | Directory to watch for new notes files |
+
+## License
+
+See [LICENSE](LICENSE).

--- a/cmd/blackwood/main.go
+++ b/cmd/blackwood/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+func main() {
+	configPath := flag.String("config", "", "path to the configuration file")
+	watchDir := flag.String("watch-dir", "", "directory to watch for new notes files")
+	flag.Parse()
+
+	if *configPath == "" || *watchDir == "" {
+		fmt.Fprintln(os.Stderr, "both --config and --watch-dir are required")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	fmt.Printf("config: %s\nwatch-dir: %s\n", *configPath, *watchDir)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/csweichel/blackwood
+
+go 1.25.0


### PR DESCRIPTION
Set up the Go project foundation:

- Initialize `github.com/csweichel/blackwood` Go module
- Add `cmd/blackwood/main.go` with `--config` and `--watch-dir` flag parsing
- Add Makefile with build, clean, test, and install targets
- Update .gitignore with `bin/` output directory
- Update README with build instructions and usage

Closes #2